### PR TITLE
fix: Trivy running even if Docker build job was exclused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ on:
         default: ""        
 
 jobs:
-  
-
   Technology_based_scans:
     name: Docker build check
     if: ${{ !(contains(fromJSON('["github-actions[bot]", "dependabot[bot]"]'), github.actor)) && (github.event_name != 'issue_comment') }}
@@ -84,6 +82,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Creating Trivy report PR comment template file
+        if: ${{ always() && !contains( inputs.excluded_jobs, 'docker' ) }}
         run: |
           cat <<EOF >> prcomment.tpl 
           | Package | Vulnerability | Severity | Status | Installed Version | Fixed Version | Title | \n
@@ -97,6 +96,7 @@ jobs:
       - name: Trivy container vulnerability scan
         id: container_scan
         uses: aquasecurity/trivy-action@master
+        if: ${{ always() && !contains( inputs.excluded_jobs, 'docker' ) }}
         with:
           image-ref: ${{ inputs.docker_build_image_id }}
           format: "template"
@@ -109,7 +109,7 @@ jobs:
           scanners: ${{ inputs.CONTAINER_SCANNERS }}
           skip-dirs: ${{ inputs.CONTAINER_SCAN_SKIP_DIRS }}
       - name: Report vulnerabilities in PR
-        if: failure() && steps.container_scan.outcome == 'failure'
+        if: ${{ failure() && steps.container_scan.outcome == 'failure' && !contains( inputs.excluded_jobs, 'docker' ) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -124,7 +124,7 @@ jobs:
             -d @result.json
 
       - name: Report no vulnerabilities in PR
-        if: success() && steps.container_scan.outcome == 'success'
+        if: ${{ success() && steps.container_scan.outcome == 'success' && !contains( inputs.excluded_jobs, 'docker' ) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -139,8 +139,6 @@ jobs:
         if: ${{ inputs.docker_after_step_command != '' }}
         run: |
           ${{ inputs.docker_after_step_command }}
-
-
 
   Security-scans:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Trivy step run condition updated not to run if Docker step is excluded.